### PR TITLE
1/n create service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,7 @@ dmypy.json
 *.swp
 *.swo
 *undo-tree*
+
+nohup.out
+
+**/*~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 79
+max-line-length = 79

--- a/test_looper/__init__.py
+++ b/test_looper/__init__.py
@@ -1,0 +1,4 @@
+from object_database import Schema
+
+
+test_looper_schema = Schema("test_looper")

--- a/test_looper/service.py
+++ b/test_looper/service.py
@@ -1,0 +1,49 @@
+# The main service class that will run this TestLooper installation
+from object_database.database_connection import DatabaseConnection
+
+from test_looper.schema import test_looper_schema
+from test_looper.service_schema import Config, ArtifactStorageConfig
+
+
+class LooperService:
+    """
+    Defines the TestLooper service
+    """
+
+    def __init__(
+        self,
+        repo_url: str,
+        temp_url: str,
+        artifact_store: ArtifactStorageConfig,
+    ):
+        """
+        Parameters
+        ----------
+        repo_url: str
+            The root url where we're going to put cloned repos
+        temp_url: str
+            The root url for temporary data
+        artifact_store: Artifactstorageconfig
+            The storage for build and test artifacts
+        """
+        self.repo_url = repo_url
+        self.temp_url = temp_url
+        self.artifact_store = artifact_store
+
+    @staticmethod
+    def from_odb(conn: DatabaseConnection) -> "LooperService":
+        """
+        Construct a LooperService by connecting to an ODB
+        instance at the given connectio
+
+        Parameters
+        ----------
+        conn: DatabaseConnection
+            The connection to odb
+        """
+        conn.subscribeToSchema(test_looper_schema)
+        with conn.view():
+            config: ArtifactStorageConfig = Config.lookupUnique()
+            return LooperService(
+                config.repo_url, config.temp_url, config.artifact_store
+            )

--- a/test_looper/service_schema.py
+++ b/test_looper/service_schema.py
@@ -1,0 +1,31 @@
+"""Define the core objects and ODB schema for test-looper."""
+from typed_python import OneOf, Alternative, TupleOf, Dict, NamedTuple
+from object_database import Indexed, Index, SubscribeLazilyByDefault
+
+
+from test_looper import test_looper_schema
+
+
+ArtifactStorageConfig = Alternative(
+    "ArtifactStorageConfig",
+    LocalDisk=dict(
+        build_artifact_path=str,
+        test_artifact_path=str,
+    ),
+    S3=dict(
+        bucket=str,
+        region=str,
+        build_artifact_key_prefix=str,
+        test_artifact_key_prefix=str,
+    ),
+    # TODO: something else fancy?
+)
+
+
+@test_looper_schema.define
+class Config:
+    """Configuration for the entire test-looper install"""
+
+    repo_url = str  # local cloned repositories
+    temp_url = str  # local temp data
+    artifact_store = ArtifactStorageConfig

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+import os
+import pytest
+import shutil
+
+from object_database.persistence import InMemoryPersistence
+from object_database.tcp_server import TcpServer, connect, DatabaseConnection
+from object_database.util import sslContextFromCertPathOrNone
+
+from test_looper import test_looper_schema
+
+# TODO read this from test configuration file
+TL_ODB_HOST = "localhost"
+TL_ODB_PORT = 8000
+TL_ODB_TOKEN = "TLTESTTOKEN"
+
+
+@pytest.fixture(scope="session")
+def odb_server() -> TcpServer:
+    server = TcpServer(
+        TL_ODB_HOST,
+        TL_ODB_PORT,
+        InMemoryPersistence(),
+        ssl_context=sslContextFromCertPathOrNone(None),
+        auth_token=TL_ODB_TOKEN,
+    )
+    server.start()
+    yield server
+    server.stop()
+
+
+@pytest.fixture(scope="module")
+def odb_conn(odb_server: TcpServer) -> DatabaseConnection:
+    conn = connect(TL_ODB_HOST, TL_ODB_PORT, TL_ODB_TOKEN, retry=True)
+    conn.subscribeToSchema(test_looper_schema)
+    yield conn
+    conn.disconnect(block=True)

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -2,6 +2,7 @@
 General Tests for Test Looper
 """
 import os
+
 # import sys
 import shutil
 import pytest
@@ -22,10 +23,10 @@ try:
 except ModuleNotFoundError:
     print("unable to import ODB - skipping ODB dependent tests")
 # GLOBALS
-repo_path = '/tmp/test_repo'
-odb_server_host = 'localhost'
+repo_path = "/tmp/test_repo"
+odb_server_host = "localhost"
 odb_server_port = 8000
-odb_server_token = 'TLTESTTOKEN'
+odb_server_token = "TLTESTTOKEN"
 
 
 class TestTestLooper:
@@ -36,14 +37,14 @@ class TestTestLooper:
         # if status:
         #    sys.exit("Could not clone test repo")
         # copy the a template directory "repo" with tests
-        shutil.copytree('tests/_template_repo', repo_path, dirs_exist_ok=True)
+        shutil.copytree("tests/_template_repo", repo_path, dirs_exist_ok=True)
         try:
             server = TcpServer(
                 odb_server_host,
                 odb_server_port,
                 InMemoryPersistence(),
                 ssl_context=sslContextFromCertPathOrNone(None),
-                auth_token=odb_server_token
+                auth_token=odb_server_token,
             )
             server.start()
             self.server = server
@@ -57,8 +58,9 @@ class TestTestLooper:
 
     @pytest.fixture(scope="module")
     def odb_connection(self):
-        odb = connect(odb_server_host, odb_server_port,
-                      odb_server_token, retry=True)
+        odb = connect(
+            odb_server_host, odb_server_port, odb_server_token, retry=True
+        )
         odb.subscribeToSchema(test_looper_schema)
         return odb
 
@@ -70,25 +72,34 @@ class TestTestLooper:
     def test_runner_list(self):
         results = self.runner.list()
         # TODO: need better inspection here once tests stabilize
-        assert isinstance(results[0][1]['retcode'].value, int)
-        assert isinstance(results[0][1]['results'], TList)
+        assert isinstance(results[0][1]["retcode"].value, int)
+        assert isinstance(results[0][1]["results"], TList)
 
     def test_runner_run(self):
         all_results = self.runner.run()
         # TODO: need better inspection here once tests stabilize
         command, results = all_results[0]
-        assert set(command.keys()) == set(['command', 'args'])
-        assert isinstance(results['retcode'].value, int)
-        assert isinstance(results['results'], TRunnerResult)
+        assert set(command.keys()) == set(["command", "args"])
+        assert isinstance(results["retcode"].value, int)
+        assert isinstance(results["results"], TRunnerResult)
 
     def test_runner_repeat(self):
         all_results = self.runner.run()
-        assert len(
-            [item for item in all_results if item[0]['args'] == [
-                'tests/test.py::TestTest::test_success']]) == 3
+        assert (
+            len(
+                [
+                    item
+                    for item in all_results
+                    if item[0]["args"]
+                    == ["tests/test.py::TestTest::test_success"]
+                ]
+            )
+            == 3
+        )
 
-    @pytest.mark.skipif(odb_connection is None,
-                        reason="no ODB connection instance found")
+    @pytest.mark.skipif(
+        odb_connection is None, reason="no ODB connection instance found"
+    )
     def test_odb_empty(self, odb_connection):
         nodes = []
         with odb_connection.view():
@@ -96,13 +107,16 @@ class TestTestLooper:
                 nodes.append(n)
             assert len(nodes) == 0
 
-    @pytest.mark.skipif(odb_connection is None,
-                        reason="no ODB connection instance found")
+    @pytest.mark.skipif(
+        odb_connection is None, reason="no ODB connection instance found"
+    )
     def test_odb_lists(self, odb_connection):
         results = self.runner.list()
         reporter = OdbReporter(odb_connection)
-        [reporter.report_tests(test_list['results'].tests)
-         for command, test_list in results]
+        [
+            reporter.report_tests(test_list["results"].tests)
+            for command, test_list in results
+        ]
         nodes = []
         with odb_connection.view():
             for n in TestNode.lookupAll():
@@ -113,4 +127,4 @@ class TestTestLooper:
     def teardown_class(self):
         if self.server:
             self.server.stop()
-        os.system(f'rm -rf {repo_path}')
+        os.system(f"rm -rf {repo_path}")

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import pytest
+
+from object_database.database_connection import DatabaseConnection
+
+from test_looper.service import LooperService
+from test_looper.service_schema import Config, ArtifactStorageConfig
+from conftest import odb_conn
+
+
+@pytest.fixture(scope="module")
+def tl_config(
+    odb_conn: DatabaseConnection, tmp_path_factory: pytest.TempPathFactory
+) -> dict:
+    """
+    Create a test looper service Config and clean it up after we're done
+    """
+    tmp_path = tmp_path_factory.mktemp("odb")
+    storage = ArtifactStorageConfig.LocalDisk(
+        build_artifact_path=str(tmp_path / "build"),
+        test_artifact_path=str(tmp_path / "test"),
+    )
+    dd = dict(
+        repo_url=str(tmp_path / "repos"),
+        temp_url=str(tmp_path / "tmp"),
+        artifact_store=storage,
+    )
+    with odb_conn.transaction():
+        config = Config(**dd)
+    yield dd
+    with odb_conn.transaction():
+        config = Config.lookupUnique()
+        config.delete()
+
+
+def test_create_service(odb_conn: DatabaseConnection, tl_config):
+    service = LooperService.from_odb(odb_conn)
+    assert service.repo_url == tl_config["repo_url"]
+    assert service.temp_url == tl_config["temp_url"]
+    assert service.artifact_store == tl_config["artifact_store"]


### PR DESCRIPTION
This PR contains some basic setup for new TestLooper.

1. Schema

- Put the test_looper_schema declaration in __init__.py
- create service_schema.py for service related schema (for now just Config but will contain stuff like WorkerConfig/Machine etc)
- we will add repo_schema.py for repos/branch/commit
- we will add test_schema.py for TestNode/TestResults/TestNodeDefinition/Command

2. Service

- We start with just the basic definition for LooperService in service.py
- All it does right now is provide a factory method to fetch Config from an odb connection

3. Test

- We create conftest.py and put the odb server as a session scoped fixture
- We create a function scoped fixture odb_conn to create new connections to odb server


Tentative plan (subject to your feedback):
1. Add schema / features to add repositories
2. Add functionality to scan a repository for new commits
3. Add functionality to parse new commits and create TestNode's

At that point I think we'll then be able to hook it up to the functionality you have now in this branch where it consumes TestNode's.

wdyt?