### PR TITLE
3/n clone a repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,7 @@ dmypy.json
 *.swp
 *.swo
 *undo-tree*
+
+nohup.out
+
+**/*~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 79
+max-line-length = 79

--- a/test_looper/__init__.py
+++ b/test_looper/__init__.py
@@ -1,0 +1,4 @@
+from object_database import Schema
+
+
+test_looper_schema = Schema("test_looper")

--- a/test_looper/repo_schema.py
+++ b/test_looper/repo_schema.py
@@ -51,3 +51,9 @@ RepoConfig = Alternative(
 class Repository:
     config = RepoConfig
     name = Indexed(str)
+
+
+@test_looper_schema.define
+class RepoClone:
+    remote = Indexed(Repository)
+    clone = Indexed(Repository)

--- a/test_looper/repo_schema.py
+++ b/test_looper/repo_schema.py
@@ -1,0 +1,53 @@
+# Define the schema related to repos, branchs, and commits
+from typed_python import Alternative
+from object_database import Indexed
+
+
+from test_looper import test_looper_schema
+
+
+# describe generic services, which can provide lots of different repos
+GitService = Alternative(
+    "GitService",
+    Github=dict(
+        oauth_key=str,
+        oauth_secret=str,
+        webhook_secret=str,
+        owner=str,  # owner we use to specify which projects to look at
+        access_token=str,
+        auth_disabled=bool,
+        github_url=str,  # usually https://github.com
+        github_login_url=str,  # usually https://github.com
+        github_api_url=str,  # usually https://github.com/api/v3
+        github_clone_url=str,  # usually git@github.com
+    ),
+    Gitlab=dict(
+        oauth_key=str,
+        oauth_secret=str,
+        webhook_secret=str,
+        group=str,  # group we use to specify which projects to show
+        private_token=str,
+        auth_disabled=bool,
+        gitlab_url=str,  # usually https://gitlab.mycompany.com
+        gitlab_login_url=str,  # usually https://gitlab.mycompany.com
+        gitlab_api_url=str,  # usually https://gitlab.mycompany.com/api/v3
+        gitlab_clone_url=str,  # usually git@gitlab.mycompany.com
+    ),
+)
+
+
+# describe how to get access to a specific repo
+RepoConfig = Alternative(
+    "RepoConfig",
+    Ssh=dict(url=str, private_key=bytes),
+    Https=dict(url=str),
+    Local=dict(path=str),
+    S3=dict(url=str),
+    FromService=dict(repo_name=str, service=GitService),
+)
+
+
+@test_looper_schema.define
+class Repository:
+    config = RepoConfig
+    name = Indexed(str)

--- a/test_looper/service.py
+++ b/test_looper/service.py
@@ -1,8 +1,12 @@
 # The main service class that will run this TestLooper installation
-from object_database.database_connection import DatabaseConnection
+import contextlib
+from typing import Union, Dict
+from urllib.parse import urlparse
 
+from object_database.database_connection import DatabaseConnection
 from test_looper.schema import test_looper_schema
-from test_looper.service_schema import Config, ArtifactStorageConfig
+from test_looper.service_schema import ArtifactStorageConfig, Config
+from test_looper.repo_schema import Repository, RepoConfig
 
 
 class LooperService:
@@ -15,6 +19,7 @@ class LooperService:
         repo_url: str,
         temp_url: str,
         artifact_store: ArtifactStorageConfig,
+        db: DatabaseConnection,
     ):
         """
         Parameters
@@ -25,25 +30,93 @@ class LooperService:
             The root url for temporary data
         artifact_store: Artifactstorageconfig
             The storage for build and test artifacts
+        db: DatabaseConnection
+            ODB connection
         """
         self.repo_url = repo_url
         self.temp_url = temp_url
         self.artifact_store = artifact_store
+        self.db = db
 
     @staticmethod
-    def from_odb(conn: DatabaseConnection) -> "LooperService":
+    def from_odb(db: DatabaseConnection) -> "LooperService":
         """
         Construct a LooperService by connecting to an ODB
         instance at the given connectio
 
         Parameters
         ----------
-        conn: DatabaseConnection
+        db: DatabaseConnection
             The connection to odb
         """
-        conn.subscribeToSchema(test_looper_schema)
-        with conn.view():
-            config: ArtifactStorageConfig = Config.lookupUnique()
+        db.subscribeToSchema(test_looper_schema)
+        with db.view():
+            config: Config = Config.lookupUnique()
             return LooperService(
-                config.repo_url, config.temp_url, config.artifact_store
+                config.repo_url, config.temp_url, config.artifact_store, db
             )
+
+    @contextlib.contextmanager
+    def add_repo(
+        self,
+        name: str,
+        config: Union[str, RepoConfig],
+        default_scheme="ssh",
+        private_key=bytes,
+    ):
+        """
+        Parameters
+        ----------
+        name: str
+            The name used to uniquely identify this repo in odb
+        config: str or RepoConfig
+            If str then parse it and create a RepoConfig
+        default_scheme: str, default "ssh"
+            If the config is str and no scheme was parsed.
+            (by default this works for git@github.com:org/repo style url)
+        private_key: bytes
+            The SSH key
+
+        yields
+        -------
+        Repository: inside the same db transaction that created it
+        """
+        if isinstance(config, str):
+            config = parse_repo_url(config, default_scheme, private_key)
+        with self.db.transaction():
+            repo = Repository(name=name, config=config)
+            yield repo
+
+    def get_repo_config(self, name: str) -> RepoConfig:
+        with self.db.view():
+            repo = Repository.lookupOne(name=name)
+            return repo.config
+
+    def get_all_repos(self) -> Dict[str, RepoConfig]:
+        with self.db.view():
+            return {repo.name: repo.config for repo in Repository.lookupAll()}
+
+
+def parse_repo_url(
+    url: str, default_scheme: str = None, private_key: bytes = None
+) -> RepoConfig:
+    rs = urlparse(url)
+    scheme = rs.scheme
+    if not scheme:
+        # make a reasonable effort to guess for common formats
+        if url.startswith("git@github.com"):
+            return RepoConfig.Ssh(url=url)
+        if url.startswith("/"):
+            return RepoConfig.Local(path=url)
+        scheme = default_scheme
+
+    if scheme == "https":
+        return RepoConfig.Https(url=url)
+    if scheme == "ssh":
+        return RepoConfig.Ssh(url=url, private_key=private_key)
+    if scheme == "file":
+        path = rs.path if not rs.netloc else f"/{rs.netloc}{rs.path}"
+        return RepoConfig.Local(path=path)
+    if scheme == "s3":
+        return RepoConfig.S3(url=url)
+    raise NotImplementedError(f"No recognized scheme for {url}")

--- a/test_looper/service.py
+++ b/test_looper/service.py
@@ -1,0 +1,49 @@
+# The main service class that will run this TestLooper installation
+from object_database.database_connection import DatabaseConnection
+
+from test_looper.schema import test_looper_schema
+from test_looper.service_schema import Config, ArtifactStorageConfig
+
+
+class LooperService:
+    """
+    Defines the TestLooper service
+    """
+
+    def __init__(
+        self,
+        repo_url: str,
+        temp_url: str,
+        artifact_store: ArtifactStorageConfig,
+    ):
+        """
+        Parameters
+        ----------
+        repo_url: str
+            The root url where we're going to put cloned repos
+        temp_url: str
+            The root url for temporary data
+        artifact_store: Artifactstorageconfig
+            The storage for build and test artifacts
+        """
+        self.repo_url = repo_url
+        self.temp_url = temp_url
+        self.artifact_store = artifact_store
+
+    @staticmethod
+    def from_odb(conn: DatabaseConnection) -> "LooperService":
+        """
+        Construct a LooperService by connecting to an ODB
+        instance at the given connectio
+
+        Parameters
+        ----------
+        conn: DatabaseConnection
+            The connection to odb
+        """
+        conn.subscribeToSchema(test_looper_schema)
+        with conn.view():
+            config: ArtifactStorageConfig = Config.lookupUnique()
+            return LooperService(
+                config.repo_url, config.temp_url, config.artifact_store
+            )

--- a/test_looper/service_schema.py
+++ b/test_looper/service_schema.py
@@ -1,0 +1,31 @@
+"""Define the core objects and ODB schema for test-looper."""
+from typed_python import OneOf, Alternative, TupleOf, Dict, NamedTuple
+from object_database import Indexed, Index, SubscribeLazilyByDefault
+
+
+from test_looper import test_looper_schema
+
+
+ArtifactStorageConfig = Alternative(
+    "ArtifactStorageConfig",
+    LocalDisk=dict(
+        build_artifact_path=str,
+        test_artifact_path=str,
+    ),
+    S3=dict(
+        bucket=str,
+        region=str,
+        build_artifact_key_prefix=str,
+        test_artifact_key_prefix=str,
+    ),
+    # TODO: something else fancy?
+)
+
+
+@test_looper_schema.define
+class Config:
+    """Configuration for the entire test-looper install"""
+
+    repo_url = str  # local cloned repositories
+    temp_url = str  # local temp data
+    artifact_store = ArtifactStorageConfig

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+import os
+import pytest
+import shutil
+
+from object_database.persistence import InMemoryPersistence
+from object_database.tcp_server import TcpServer, connect, DatabaseConnection
+from object_database.util import sslContextFromCertPathOrNone
+
+from test_looper import test_looper_schema
+
+# TODO read this from test configuration file
+TL_ODB_HOST = "localhost"
+TL_ODB_PORT = 8000
+TL_ODB_TOKEN = "TLTESTTOKEN"
+
+
+@pytest.fixture(scope="session")
+def odb_server() -> TcpServer:
+    server = TcpServer(
+        TL_ODB_HOST,
+        TL_ODB_PORT,
+        InMemoryPersistence(),
+        ssl_context=sslContextFromCertPathOrNone(None),
+        auth_token=TL_ODB_TOKEN,
+    )
+    server.start()
+    yield server
+    server.stop()
+
+
+@pytest.fixture(scope="module")
+def odb_conn(odb_server: TcpServer) -> DatabaseConnection:
+    conn = connect(TL_ODB_HOST, TL_ODB_PORT, TL_ODB_TOKEN, retry=True)
+    conn.subscribeToSchema(test_looper_schema)
+    yield conn
+    conn.disconnect(block=True)

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -2,6 +2,7 @@
 General Tests for Test Looper
 """
 import os
+
 # import sys
 import shutil
 import pytest
@@ -22,10 +23,10 @@ try:
 except ModuleNotFoundError:
     print("unable to import ODB - skipping ODB dependent tests")
 # GLOBALS
-repo_path = '/tmp/test_repo'
-odb_server_host = 'localhost'
+repo_path = "/tmp/test_repo"
+odb_server_host = "localhost"
 odb_server_port = 8000
-odb_server_token = 'TLTESTTOKEN'
+odb_server_token = "TLTESTTOKEN"
 
 
 class TestTestLooper:
@@ -36,14 +37,14 @@ class TestTestLooper:
         # if status:
         #    sys.exit("Could not clone test repo")
         # copy the a template directory "repo" with tests
-        shutil.copytree('tests/_template_repo', repo_path, dirs_exist_ok=True)
+        shutil.copytree("tests/_template_repo", repo_path, dirs_exist_ok=True)
         try:
             server = TcpServer(
                 odb_server_host,
                 odb_server_port,
                 InMemoryPersistence(),
                 ssl_context=sslContextFromCertPathOrNone(None),
-                auth_token=odb_server_token
+                auth_token=odb_server_token,
             )
             server.start()
             self.server = server
@@ -57,8 +58,9 @@ class TestTestLooper:
 
     @pytest.fixture(scope="module")
     def odb_connection(self):
-        odb = connect(odb_server_host, odb_server_port,
-                      odb_server_token, retry=True)
+        odb = connect(
+            odb_server_host, odb_server_port, odb_server_token, retry=True
+        )
         odb.subscribeToSchema(test_looper_schema)
         return odb
 
@@ -70,25 +72,34 @@ class TestTestLooper:
     def test_runner_list(self):
         results = self.runner.list()
         # TODO: need better inspection here once tests stabilize
-        assert isinstance(results[0][1]['retcode'].value, int)
-        assert isinstance(results[0][1]['results'], TList)
+        assert isinstance(results[0][1]["retcode"].value, int)
+        assert isinstance(results[0][1]["results"], TList)
 
     def test_runner_run(self):
         all_results = self.runner.run()
         # TODO: need better inspection here once tests stabilize
         command, results = all_results[0]
-        assert set(command.keys()) == set(['command', 'args'])
-        assert isinstance(results['retcode'].value, int)
-        assert isinstance(results['results'], TRunnerResult)
+        assert set(command.keys()) == set(["command", "args"])
+        assert isinstance(results["retcode"].value, int)
+        assert isinstance(results["results"], TRunnerResult)
 
     def test_runner_repeat(self):
         all_results = self.runner.run()
-        assert len(
-            [item for item in all_results if item[0]['args'] == [
-                'tests/test.py::TestTest::test_success']]) == 3
+        assert (
+            len(
+                [
+                    item
+                    for item in all_results
+                    if item[0]["args"]
+                    == ["tests/test.py::TestTest::test_success"]
+                ]
+            )
+            == 3
+        )
 
-    @pytest.mark.skipif(odb_connection is None,
-                        reason="no ODB connection instance found")
+    @pytest.mark.skipif(
+        odb_connection is None, reason="no ODB connection instance found"
+    )
     def test_odb_empty(self, odb_connection):
         nodes = []
         with odb_connection.view():
@@ -96,13 +107,16 @@ class TestTestLooper:
                 nodes.append(n)
             assert len(nodes) == 0
 
-    @pytest.mark.skipif(odb_connection is None,
-                        reason="no ODB connection instance found")
+    @pytest.mark.skipif(
+        odb_connection is None, reason="no ODB connection instance found"
+    )
     def test_odb_lists(self, odb_connection):
         results = self.runner.list()
         reporter = OdbReporter(odb_connection)
-        [reporter.report_tests(test_list['results'].tests)
-         for command, test_list in results]
+        [
+            reporter.report_tests(test_list["results"].tests)
+            for command, test_list in results
+        ]
         nodes = []
         with odb_connection.view():
             for n in TestNode.lookupAll():
@@ -113,4 +127,4 @@ class TestTestLooper:
     def teardown_class(self):
         if self.server:
             self.server.stop()
-        os.system(f'rm -rf {repo_path}')
+        os.system(f"rm -rf {repo_path}")

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,10 +1,12 @@
 from pathlib import Path
-import pytest
+from urllib.parse import urlparse
 
 from object_database.database_connection import DatabaseConnection
+import pytest
 
-from test_looper.service import LooperService
+from test_looper.service import LooperService, parse_repo_url
 from test_looper.service_schema import Config, ArtifactStorageConfig
+from test_looper.repo_schema import Repository, RepoConfig
 from conftest import odb_conn
 
 
@@ -38,3 +40,49 @@ def test_create_service(odb_conn: DatabaseConnection, tl_config):
     assert service.repo_url == tl_config["repo_url"]
     assert service.temp_url == tl_config["temp_url"]
     assert service.artifact_store == tl_config["artifact_store"]
+
+
+def test_add_repo(odb_conn: DatabaseConnection, tl_config):
+    service = LooperService.from_odb(odb_conn)
+    # TODO test the FromService variant
+    # test_parse_repo tests adding the other types
+    repos = {
+        "test-looper": "https://github.com/aprioriinvestments/test-looper",
+        "typed_python": "https://github.com/aprioriinvestments/typed_python",
+        "odb": "https://github.com/aprioriinvestments/object_database",
+    }
+    for name, url in repos.items():
+        with service.add_repo(name, url) as repo:
+            assert repo.name == name
+            assert repo.config.url == url
+
+    all_repos = service.get_all_repos()
+    for name, config in all_repos.items():
+        assert repos[name] == config.url
+
+    for name, url in repos.items():
+        config = service.get_repo_config(name)
+        assert isinstance(config, RepoConfig.Https)
+        assert config.url == url
+
+
+def test_parse_repo():
+    alternatives = [
+        (RepoConfig.Ssh, "ssh://user@foo.com:org/repo", {"private_key": b""}),
+        (RepoConfig.Ssh, "git@github.com:org/repo", {"private_key": b""}),
+        (RepoConfig.Https, "https://github.com/org/repo", {}),
+        (RepoConfig.Local, "file:///path/to/repo", {}),
+        (RepoConfig.Local, "/path/to/repo", {}),
+        (RepoConfig.S3, "s3://bucket/path/to/repo", {}),
+    ]
+    for i, (klass, conf_str, kwargs) in enumerate(alternatives):
+        _check_str_repo_config(klass, f"tl-{i}", conf_str, **kwargs)
+
+
+def _check_str_repo_config(klass, name, url, **kwargs):
+    config = parse_repo_url(url, **kwargs)
+    assert isinstance(config, klass)
+    if klass == RepoConfig.Local:
+        assert config.path == urlparse(url).path
+    else:
+        assert config.url == url

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -52,10 +52,7 @@ def test_add_repo(odb_conn: DatabaseConnection, tl_config):
         "odb": "https://github.com/aprioriinvestments/object_database",
     }
     for name, url in repos.items():
-        with service.add_repo(name, url) as repo:
-            assert repo.name == name
-            assert repo.config.url == url
-
+        service.add_repo(name, url)
     all_repos = service.get_all_repos()
     for name, config in all_repos.items():
         assert repos[name] == config.url
@@ -64,6 +61,21 @@ def test_add_repo(odb_conn: DatabaseConnection, tl_config):
         config = service.get_repo_config(name)
         assert isinstance(config, RepoConfig.Https)
         assert config.url == url
+
+
+def test_clone_repo(odb_conn: DatabaseConnection, tl_config):
+    service = LooperService.from_odb(odb_conn)
+    name = "test-looper"
+    config = service.add_repo(
+        name, "https://github.com/aprioriinvestments/test-looper"
+    )
+    clone_name, clone_config = service.clone_repo(name, clone_name="clone")
+    assert clone_name == "clone"
+    assert isinstance(clone_config, RepoConfig.Local)
+    assert clone_config.path == f"{service.repo_url}/clone"
+    remote_name, remote_config = service.get_remote(clone_name)
+    assert remote_name == name
+    assert remote_config == config
 
 
 def test_parse_repo():

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import pytest
+
+from object_database.database_connection import DatabaseConnection
+
+from test_looper.service import LooperService
+from test_looper.service_schema import Config, ArtifactStorageConfig
+from conftest import odb_conn
+
+
+@pytest.fixture(scope="module")
+def tl_config(
+    odb_conn: DatabaseConnection, tmp_path_factory: pytest.TempPathFactory
+) -> dict:
+    """
+    Create a test looper service Config and clean it up after we're done
+    """
+    tmp_path = tmp_path_factory.mktemp("odb")
+    storage = ArtifactStorageConfig.LocalDisk(
+        build_artifact_path=str(tmp_path / "build"),
+        test_artifact_path=str(tmp_path / "test"),
+    )
+    dd = dict(
+        repo_url=str(tmp_path / "repos"),
+        temp_url=str(tmp_path / "tmp"),
+        artifact_store=storage,
+    )
+    with odb_conn.transaction():
+        config = Config(**dd)
+    yield dd
+    with odb_conn.transaction():
+        config = Config.lookupUnique()
+        config.delete()
+
+
+def test_create_service(odb_conn: DatabaseConnection, tl_config):
+    service = LooperService.from_odb(odb_conn)
+    assert service.repo_url == tl_config["repo_url"]
+    assert service.temp_url == tl_config["temp_url"]
+    assert service.artifact_store == tl_config["artifact_store"]


### PR DESCRIPTION
`LooperService.clone_repo` will clone a repo registered in ODB to a
local directory (using the `repo_url` attribute for the service). A
custom clone_name can be specified. If omitted, then a unique one is
generated of the format <orig>-clone-<uuid4>.

Again this is on top of #5 and #6 but I've separated it out for easier review