### PR TITLE
Parse branches and commits

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,8 @@
 from distutils.core import setup
 
-setup(name='test_looper',
-      version='0.1',
-      py_modules=['test_looper'],
-      install_requires=[
-          'requests',
-          'pytest'
-      ],
-      )
+setup(
+    name="test_looper",
+    version="0.1",
+    py_modules=["test_looper"],
+    install_requires=["requests", "pytest", "gitpython"],
+)

--- a/test_looper/git.py
+++ b/test_looper/git.py
@@ -44,10 +44,5 @@ class GIT:
         """
         return os.system(f"git clone {repo} {directory}")
 
-    def list_commits(self, repo: str, rev: str = None):
-        """
-        Return a generator of GitPython's Commit objects for the given repo.
-        If specified, the `rev` str will be used to constrain the commits
-        listed to a range (e.g., "<revA>...<revB>")
-        """
-        return Repo(repo).iter_commits(rev=rev)
+    def get_commit(self, repo, ref):
+        return Repo(repo).commit(ref)

--- a/test_looper/git.py
+++ b/test_looper/git.py
@@ -5,6 +5,9 @@ import os
 import sys
 import requests
 
+# GitPython
+from git import Repo
+
 
 class GIT:
     def __init__(self, user=None, token=None, require_auth=False):
@@ -21,9 +24,9 @@ class GIT:
         self.session.auth = (self.user, self.token)
         # check the credentials are valid
         response = self.session.get(
-            'https://api.github.com/users/%s' % self.user
+            "https://api.github.com/users/%s" % self.user
         )
-        if response.headers['X-RateLimit-Limit'] == '5000':
+        if response.headers["X-RateLimit-Limit"] == "5000":
             self.authenticated = True
         elif self.require_auth:
             sys.exit("invalid github credentials")
@@ -37,6 +40,14 @@ class GIT:
         repo: str
             local path or url for repo
         directory: str
-            path to target directory 
+            path to target directory
         """
-        return os.system(f'git clone {repo} {directory}')
+        return os.system(f"git clone {repo} {directory}")
+
+    def list_commits(self, repo: str, rev: str = None):
+        """
+        Return a generator of GitPython's Commit objects for the given repo.
+        If specified, the `rev` str will be used to constrain the commits
+        listed to a range (e.g., "<revA>...<revB>")
+        """
+        return Repo(repo).iter_commits(rev=rev)

--- a/test_looper/git.py
+++ b/test_looper/git.py
@@ -65,3 +65,9 @@ class GIT:
             if h.name == ref:
                 return h
         raise ValueError(f"{ref} branch was not found in {repo}")
+
+    def list_branches(self, repo):
+        return Repo(repo).heads
+
+    def get_head(self, repo):
+        return Repo(repo).head

--- a/test_looper/git.py
+++ b/test_looper/git.py
@@ -2,6 +2,7 @@
 # with GIT, github and related utilities
 
 import os
+import subprocess
 import sys
 import requests
 
@@ -33,7 +34,7 @@ class GIT:
         else:
             self.authenticated = False
 
-    def clone(self, repo, directory):
+    def clone(self, repo, directory, all_branches=False):
         """
         Parameters:
         ----------
@@ -41,8 +42,26 @@ class GIT:
             local path or url for repo
         directory: str
             path to target directory
+        all_branches: bool, default False
+            if True then clone with all remote branches
         """
-        return os.system(f"git clone {repo} {directory}")
+        if not all_branches:
+            return os.system(f"git clone {repo} {directory}")
+        else:
+            os.makedirs(directory, exist_ok=True)
+            cmd = (
+                f"cd {directory} && "
+                f"git clone --mirror {repo} .git && "
+                "git config --bool core.bare false && "
+                "git reset --hard"
+            )
+            return subprocess.check_output(cmd, shell=True)
 
     def get_commit(self, repo, ref):
         return Repo(repo).commit(ref)
+
+    def get_branch(self, repo, ref):
+        for h in Repo(repo).heads:
+            if h.name == ref:
+                return h
+        raise ValueError(f"{ref} branch was not found in {repo}")

--- a/test_looper/repo_schema.py
+++ b/test_looper/repo_schema.py
@@ -1,6 +1,6 @@
 # Define the schema related to repos, branchs, and commits
 from typed_python import Alternative, NamedTuple
-from object_database import Indexed
+from object_database import Indexed, Index
 
 
 from test_looper import test_looper_schema
@@ -105,7 +105,7 @@ class CommitParent:
 
 @test_looper_schema.define
 class Branch:
-    repo = Indexed(Repo)
+    repo = Indexed(Repository)
     name = str
 
     repoAndName = Index("repo", "name")

--- a/test_looper/repo_schema.py
+++ b/test_looper/repo_schema.py
@@ -41,7 +41,7 @@ RepoConfig = Alternative(
     "RepoConfig",
     Ssh=dict(url=str, private_key=bytes),
     Https=dict(url=str),
-    Local=dict(path=str),
+    Local=dict(path=str),  # TODO identify the host at this ID?
     S3=dict(url=str),
     FromService=dict(repo_name=str, service=GitService),
 )
@@ -53,10 +53,12 @@ class Repository:
     name = Indexed(str)
 
 
+# TODO do we actually want to manage local clones in ODB?
 @test_looper_schema.define
 class RepoClone:
     remote = Indexed(Repository)
     clone = Indexed(Repository)
+    # TODO add a machine id here since clones are local?
 
 
 @test_looper_schema.define

--- a/test_looper/schema.py
+++ b/test_looper/schema.py
@@ -11,6 +11,7 @@ test_looper_schema = Schema("test_looper")
 GitService = Alternative(
     "GitService",
     Github=dict(
+        account_name=str,  # for display
         oauth_key=str,
         oauth_secret=str,
         webhook_secret=str,

--- a/test_looper/service.py
+++ b/test_looper/service.py
@@ -187,7 +187,12 @@ def parse_repo_url(
     raise NotImplementedError(f"No recognized scheme for {url}")
 
 
-def parse_branch(repo: Repository, branch_name: str):
+def parse_branch(repo: Repository, branch_name: str) -> Branch:
+    """
+    Go through the designated branch and register everything as necessary
+    in odb. This includes 1) the branch itself, 2) commits and parents
+    and 3) commit parent relationship
+    """
     b = GIT().get_branch(repo.path, branch_name)
     top_commit = parse_commits(repo, b.commit)
     odb_b = Branch.lookupOne(repoAndName(repo, branch_name))
@@ -200,9 +205,10 @@ def parse_branch(repo: Repository, branch_name: str):
         )
     else:
         odb_b.top_commit = top_commit
+    return odb_b
 
 
-def parse_commits(repo: Repository, commit: "git.Commit"):
+def parse_commits(repo: Repository, commit: "git.Commit") -> Commit:
     """
     Start from the commit sha given in `head` and keep traversing commit
     parents until all parents are already in odb or no more parents exist.
@@ -213,6 +219,11 @@ def parse_commits(repo: Repository, commit: "git.Commit"):
         The local repo whose active branch we want to parse commits from
     head: str
         The commit SHA where we want to start from (usually tip of a branch)
+
+    Returns
+    -------
+    c: Commit
+        The top commit as an ODB object
     """
     top_commit = make_commit(repo, commit)
     to_process = [(top_commit, commit.parents)]

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,7 +1,7 @@
 import json
 import os
 
-from test_looper.git import GIT
+from test_looper.git import GIT, Repo
 
 
 class TestGit:
@@ -17,8 +17,7 @@ class TestGit:
         if os.path.isfile(cred_file):
             print("GIT credentials found")
             credentials = json.load(open(cred_file))
-            cls.GIT = GIT(user=credentials["user"],
-                          token=credentials["token"])
+            cls.GIT = GIT(user=credentials["user"], token=credentials["token"])
             cls.GIT.authenticate()
             if cls.GIT.authenticated:
                 print("authenticated")
@@ -36,3 +35,15 @@ class TestGit:
     @classmethod
     def teardown_class(cls):
         return
+
+
+def test_list_commits(tmp_path):
+    test_looper = "https://github.com/aprioriinvestments/test-looper"
+    git = GIT()
+    git.clone(test_looper, str(tmp_path))
+    commits = list(git.list_commits(str(tmp_path)))
+    assert len(commits) > 0
+    for c in commits:
+        for prop in [c.hexsha, c.author.name, c.author.email, c.summary]:
+            assert prop is not None
+            assert len(prop) > 0

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -35,15 +35,3 @@ class TestGit:
     @classmethod
     def teardown_class(cls):
         return
-
-
-def test_list_commits(tmp_path):
-    test_looper = "https://github.com/aprioriinvestments/test-looper"
-    git = GIT()
-    git.clone(test_looper, str(tmp_path))
-    commits = list(git.list_commits(str(tmp_path)))
-    assert len(commits) > 0
-    for c in commits:
-        for prop in [c.hexsha, c.author.name, c.author.email, c.summary]:
-            assert prop is not None
-            assert len(prop) > 0

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,7 +1,8 @@
 import json
 import os
 
-from test_looper.git import GIT, Repo
+from test_looper.git import GIT
+from test_looper.git import Repo as GitPythonRepo
 
 
 class TestGit:


### PR DESCRIPTION
Extend the LooperService to scan a registered repo to add branches / commits to setup for test parsing.

Assuming you have an odb DatabaseConnection called `odb_conn`:

```python
from test_looper.service import LooperService

service = LooperService(odb_conn)
service.add_repo("test-looper", "https://github.com//aprioriinvestments/test-looper")
service.clone_repo("test-looper", "my-test-looper-clone")
service.scan_repo("my-test-looper-clone", branch="*")
```

The result of the above snippet should be that the ODB instance will have:
- 2 Repository objects and 1 RepoClone object associating the two
- All the Branches for the local clone "my-test-looper-clone"
- All Commits for the local clone
- CommitParent relationships matching the local clone repo

*If you omit the `branch` keyword argument then only the default branch is parsed.