### PR TITLE
Parse tests

### DIFF
--- a/test_looper/parser.py
+++ b/test_looper/parser.py
@@ -1,0 +1,100 @@
+"""Service to parse commits and create a test plan"""
+import contextlib
+from functools import wraps
+import json
+
+from object_database.database_connection import DatabaseConnection
+
+from test_looper.repo_schema import Commit, RepoConfig
+from test_looper.test_schema import TestNode, Command, TestNodeDefinition
+from test_looper.tl_git import GIT
+
+
+def view(f):
+    @wraps(f)
+    def view_func(self, *args, **kwargs):
+        with self.db.view():
+            return f(self, *args, **kwargs)
+    return view_func
+
+
+def transaction(f):
+    @wraps(f)
+    def trans_func(self, *args, **kwargs):
+        with self.db.transaction():
+            return f(self, *args, **kwargs)
+    return trans_func
+
+
+class TestParserService:
+
+    def __init__(self, db: DatabaseConnection, repo_url: str):
+        self.db = db
+        self.repo_url = repo_url
+
+    @transaction
+    def parse_commits(self, max_num_commits: int = None) -> int:
+        """
+
+        Parameters
+        ----------
+        max_num_commits: int, default None
+            Parse up to this many commits. If unspecified then parse all commits where `is_parsed=False`
+
+        Returns
+        -------
+        num_parsed: number of commits successfully parsed
+        """
+        num_parsed = 0
+        for i, c in enumerate(Commit.lookupAll(is_parsed=False)):
+            num_parsed += self._parse(c)
+            if max_num_commits is not None and 0 < max_num_commits <= i:
+                break
+        return num_parsed
+
+    def _parse(self, commit: Commit):
+        conf = commit.repo.config
+        assert(isinstance(conf, RepoConfig.Local))
+        tl_conf = self._parse_tl_json(commit.sha, conf.path)
+        if tl_conf is None:
+            return False
+        self._create_test_plan(commit, tl_conf)
+        commit.is_parsed = True
+        return True
+
+    @staticmethod
+    def _parse_tl_json(sha: str, repo_path: str) -> dict:
+        try:
+            tl_json_str = GIT().read_file(repo_path, 'test_looper.json', ref=sha)
+            return json.loads(tl_json_str)
+        except (FileNotFoundError, ValueError):
+            # TODO add some schema objects to record unparseable commits?
+            pass
+
+    def _create_test_plan(self, commit: Commit, conf: dict):
+        keys = ["build_commands", "docker_commands", "test_commands"]
+        for k in keys:
+            commands = conf.get(k)
+            if commands is not None:
+                getattr(self, f'_parse_{k}')(commit, commands)
+
+    @staticmethod
+    def _parse_test_commands(commit: Commit, cmd_conf: list):
+        for cmd in cmd_conf:
+            c = Command(bashCommand=f"{cmd['command']} {' '.join(cmd['args'])}")
+            test_def = TestNodeDefinition.Test(runTests=c)
+            TestNode(commit=commit,
+                     name="???",
+                     definition=test_def,
+                     needsMoreWork=True)
+
+    @staticmethod
+    def _parse_build_commands(commit: Commit, cmd_txt: list):
+        # TODO decide on the format and imlement
+        raise NotImplementedError()
+
+    @staticmethod
+    def _parse_docker_image(commit: Commit, cmd_txt: list):
+        # TODO decide on the format and imlement
+        raise NotImplementedError()
+

--- a/test_looper/test_schema.py
+++ b/test_looper/test_schema.py
@@ -1,0 +1,91 @@
+from typed_python import Alternative, NamedTuple, Dict, TupleOf, OneOf
+from object_database import Indexed, Index, SubscribeLazilyByDefault
+
+from test_looper import test_looper_schema
+
+
+# model a command that produces a specific output
+from test_looper.repo_schema import Commit
+
+
+Command = NamedTuple(
+    # named docker image
+    dockerImageName=str,
+    environmentVariables=Dict(str, str),
+    bashCommand=str,
+    timeoutSeconds=float
+)
+
+
+# model a single entry in a test plan. The collection of these must form a DAG
+# with 'Test'
+TestNodeDefinition = Alternative(
+    "TestNodeDefinition",
+    # run arbitrary code to produce a set of binary outputs
+    Build=dict(
+        inputs=TupleOf(str), # the named inputs
+        outputs=TupleOf(str), # list of named outputs
+        minCpus=int,
+        minRamGb=float,
+        command=Command,
+    ),
+    # run arbitrary code to produce the text of a docker image
+    # then build that docker image
+    DockerImage=dict(
+        inputs=TupleOf(str), # the named inputs
+    ),
+    # run arbitrary code to produce a list of tests, and then run them
+    Test=dict(
+        inputs=TupleOf(str), # named inputs
+        minCpus=int,
+        minRamGb=float,
+        listTests=Command,
+        runTests=Command
+    )
+)
+
+
+@test_looper_schema.define
+class TestNode:
+    commit = Indexed(Commit)
+    name = str
+
+    commitAndName = Index('commit', 'name')
+
+    definition = TestNodeDefinition
+
+    # None means we haven't run it yet
+    # Fail means we couldn't do the build, list tests, or execute tests.
+    # Timeout means we timed out doing the same.
+    # Success means we were able to perform the action. It doesn't mean that
+    # the individual tests within the suite succeeded.
+    # For a build node, success will mean that the artifact store has all build objects
+    # populated, and that the artifact store has logs available
+    executionResultSummary = OneOf(None, "Fail", "Timeout", "Success")
+
+    # if we're a test (not a build), then some summary stats
+    testsDefined = OneOf(None, int)
+    testsExecutedAtLeastOnce = OneOf(None, int)
+    testsFailing = OneOf(None, int)
+    testsNewlyFailing = OneOf(None, int)
+    testsNewlyFixed = OneOf(None, int)
+
+    # crude proxy for the state machine we'll need to decide what to build/run
+    needsMoreWork = Indexed(bool)
+
+
+TestResult = NamedTuple(
+    # guid we can use to pull relevant logs from the artifact store
+    testId=str,
+    success=bool,
+    startTime=float,
+    executionTime=float
+)
+
+
+@test_looper_schema.define
+@SubscribeLazilyByDefault
+class TestResults:
+    node = Indexed(TestNode)
+
+    testResults = Dict(str, TupleOf(TestResult))

--- a/test_looper/tl_git.py
+++ b/test_looper/tl_git.py
@@ -71,3 +71,19 @@ class GIT:
 
     def get_head(self, repo):
         return Repo(repo).head
+
+    def read_file(self, repo, file_path, ref) -> str:
+        """Get a file from repo at a given reference"""
+        cmd = f'cd {repo} && git show {ref}:{file_path} | cat'
+        with subprocess.Popen(cmd,
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE,
+                              shell=True) as proc:
+            stderr = proc.stderr.read().decode('utf-8').strip()
+            stdout = proc.stdout.read().decode('utf-8').strip()
+            err = f"fatal: path '{file_path}' does not exist in '{ref}'"
+            if stderr == err:
+                raise FileNotFoundError(stderr)
+            if len(stdout) == 0:
+                raise ValueError("test_looper.json was empty")
+            return stdout

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,38 @@
+"""Test the test parser"""
+import hashlib
+import pytest
+from object_database.database_connection import DatabaseConnection
+
+from test_looper.parser import TestParserService
+from test_looper.repo_schema import Commit, RepoConfig, Repository
+from test_looper.service import LooperService
+from test_looper.test_schema import TestNode
+
+
+@pytest.fixture
+def parser_service(odb_conn: DatabaseConnection,
+                   tl_config: dict) -> TestParserService:
+    setup_repo(odb_conn)
+    return TestParserService(odb_conn, tl_config["repo_url"])
+
+
+def setup_repo(odb_conn: DatabaseConnection):
+    service = LooperService.from_odb(odb_conn)
+    service.add_repo(
+        "test-looper", "https://github.com//aprioriinvestments/test-looper"
+    )
+    service.clone_repo("test-looper", "my-test-looper-clone")
+    service.scan_repo("my-test-looper-clone", branch="*")
+
+
+def test_parse_commits(parser_service: TestParserService):
+    with parser_service.db.view():
+        assert len(TestNode.lookupAll()) == 0
+    parser_service.parse_commits()
+    with parser_service.db.view():
+        nodes = TestNode.lookupAll()
+        assert len(nodes) > 0
+        test_def = nodes[0].definition
+        assert test_def.runTests.bashCommand is not None
+
+


### PR DESCRIPTION
For every Commit where Commit.is_parsed is False, we try to read the test_looper.json for that commit and create a TestNode out of it.

1. This only parses the commands as it exists today in the test_looper.json today. My suggestion here is we come back after we test out some end-to-end workflows and try to formalize the test_looper.json schema after that.
2. This PR does not execute the tests or record test results. That will be a separate PR.