### PR TITLE
Refactor local clone management

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,12 +5,14 @@ import click
 from test_looper.test_schema import TestResults
 from test_looper.utils.services import run_tests
 
+
 @click.command()
 @click.option('-h', '--host', default='localhost')
 @click.option('-p', '--port', default='8000')
 @click.option('-t', '--token', default='TOKEN')
 def main(host, port, token):
     odb = run_tests(host, port, token)
+
     with odb.view():
         for tr in TestResults.lookupAll():
             print(f'{tr.node.name} has {tr.node.testsDefined} tests defined')

--- a/test_looper/repo_schema.py
+++ b/test_looper/repo_schema.py
@@ -54,20 +54,6 @@ class Repository:
     config = RepoConfig
     name = Indexed(str)
 
-    def checkout(self, ref: str):
-        if isinstance(self.config, RepoConfig.Local):
-            GIT().checkout(self.config.path, ref)
-        else:
-            raise NotImplementedError()
-
-
-# TODO do we actually want to manage local clones in ODB?
-@test_looper_schema.define
-class RepoClone:
-    remote = Indexed(Repository)
-    clone = Indexed(Repository)
-    # TODO add a machine id here since clones are local?
-
 
 @test_looper_schema.define
 class Commit:

--- a/test_looper/service.py
+++ b/test_looper/service.py
@@ -1,22 +1,20 @@
 # The main service class that will run this TestLooper installation
-import os
-import click
-from typing import Dict, Optional, Union
+from typing import Optional, Union
 from urllib.parse import urlparse
-import uuid
 
 from object_database.database_connection import DatabaseConnection
-from test_looper.tl_git import GIT
+
+from test_looper import test_looper_schema
 from test_looper.repo_schema import (
     Branch,
     Commit,
     CommitParent,
     Repository,
     RepoConfig,
-    RepoClone,
 )
-from test_looper import test_looper_schema
 from test_looper.service_schema import ArtifactStorageConfig, Config
+
+from test_looper.tl_git import GIT
 from test_looper.utils.db import ServiceMixin, transaction, view
 
 
@@ -44,8 +42,7 @@ class LooperService(ServiceMixin):
         db: DatabaseConnection
             ODB connection
         """
-        super(LooperService, self).__init__(db)
-        self.repo_url = repo_url
+        super(LooperService, self).__init__(db, repo_url)
         self.temp_url = temp_url
         self.artifact_store = artifact_store
 
@@ -81,6 +78,7 @@ class LooperService(ServiceMixin):
         config: Union[str, RepoConfig],
         default_scheme="ssh",
         private_key=bytes,
+        on_exist="ignore"
     ) -> RepoConfig:
         """
         Parameters
@@ -94,6 +92,9 @@ class LooperService(ServiceMixin):
             (by default this works for git@github.com:org/repo style url)
         private_key: bytes
             The SSH key
+        on_exist: str, default "ignore"
+            "ignore", "error", "overwrite" => what to do if the name already
+            exists
 
         yields
         -------
@@ -102,112 +103,41 @@ class LooperService(ServiceMixin):
         if isinstance(config, str):
             config = parse_repo_url(config, default_scheme, private_key)
         repo = Repository.lookupAny(name=name)
-        # TODO: revist this, maybe the repo should be deleted first if found
-        # if repo:
-        #    assert repo.config == config
-        # else:
-        #    repo = Repository(name=name, config=config)
         if not repo:
             repo = Repository(name=name, config=config)
+        else:
+            if on_exist == "error":
+                raise ValueError(f"Repo {name} is already registered")
+            elif on_exist == "overwrite":
+                repo.delete()
+                repo = Repository(name=name, config=config)
         return repo.config
-
-    @view
-    def get_repo_config(self, name: str) -> Optional[RepoConfig]:
-        repo = Repository.lookupAny(name=name)
-        if repo is not None:
-            return repo.config
-
-    @view
-    def get_all_repos(self) -> Dict[str, RepoConfig]:
-        return {repo.name: repo.config for repo in Repository.lookupAll()}
-
-    def clone_repo(
-        self, name: str, clone_name: str = None
-    ) -> (str, RepoConfig):
-        """
-        Clone a registered repo with the given name to this service's
-        repo storage. A RepoClone link will be added between the remote
-        repo storage. A RepoClone link will be added between the remote
-        and local clone
-
-        Parameters
-        ----------
-        name: str
-            The odb name of the repo to be cloned
-        clone_name: str, default None
-            The odb name of the clone. If not provided, then it will
-            be <name>-clone-<uuid>
-
-        Returns
-        -------
-        (clone_name, clone_config): (str, RepoConfig)
-        """
-        if clone_name is None:
-            clone_name = f"{name}-clone-{str(uuid.uuid4())}"
-        with self.db.view():
-            clone_repo = Repository.lookupAny(name=clone_name)
-            if clone_repo is not None:
-                return clone_repo.name, clone_repo.config
-
-        clone_path = os.path.join(self.repo_url, clone_name)
-        to_clone = self.get_repo_config(name)
-        if to_clone is None:
-            raise KeyError(f"Repo {name} is not registered in odb")
-        _create_clone(to_clone, clone_path)
-        with self.db.transaction():
-            clone_conf = RepoConfig.Local(path=clone_path)
-            clone_repo = Repository(name=clone_name, config=clone_conf)
-            orig_repo = Repository.lookupOne(name=name)
-            RepoClone(remote=orig_repo, clone=clone_repo)
-            return clone_name, clone_repo.config
-
-    @view
-    def get_remote(self, clone_name: str) -> (str, RepoConfig):
-        """
-        Get the remote repo that originated the local repo with the given
-        clone_name
-        """
-        clone = Repository.lookupOne(name=clone_name)
-        remote = RepoClone.lookupOne(clone=clone).remote
-        return remote.name, remote.config
 
     @transaction
     def scan_repo(self, repo_name: str, branch: Optional[str]):
         """
-        Scan the given repo / branch and add Branches/Commits etc to odb.
-
-        Parameters
-        ----------
-        repo_name: str
-            Name of the local odb repository to scan
-        branch: str or list-like of str, default None
-            If None then just the default branch is scanned.
-            If it's a str then assume it's branch name
-            If the string is '*' then scan all branches
+        Scan the specified repo. If no branch is specified, only the
+        default branch is scanned.
         """
         repo = Repository.lookupOne(name=repo_name)
-        if not isinstance(repo.config, RepoConfig.Local):
-            repo = RepoClone.lookupOne(remote=repo).clone
+        if repo is None:
+            raise KeyError(f"Repository {repo_name} is not registered")
+        is_found, clone_path = self.get_clone(repo)
+        if not is_found:
+            _create_clone(repo.config, clone_path)
         g = GIT()
         if branch is None:
-            to_scan = [g.get_head(repo.config.path)]
+            to_scan = [g.get_head(clone_path)]
         elif branch == "*":
-            to_scan = g.list_branches(repo.config.path)
+            to_scan = g.list_branches(clone_path)
         elif isinstance(branch, str):
-            to_scan = [g.get_branch(repo.config.path, branch)]
+            to_scan = [g.get_branch(clone_path, branch)]
         elif isinstance(branch, (list, tuple)):
-            to_scan = [g.get_branch(repo.config.path, b) for b in branch]
+            to_scan = [g.get_branch(clone_path, b) for b in branch]
         else:
             raise NotImplementedError()
         for b in to_scan:
             parse_branch(repo, b)
-
-
-def _create_clone(conf: RepoConfig, clone_path):
-    if isinstance(conf, RepoConfig.Https):
-        GIT().clone(conf.url, clone_path, all_branches=True)
-    else:
-        raise NotImplementedError("Only public https cloning supported")
 
 
 def parse_repo_url(
@@ -262,9 +192,9 @@ def parse_commits(repo: Repository, commit: "git.Commit") -> Commit:
 
     Parameters
     ----------
-    repo: RepoConfig.Local
-        The local repo whose active branch we want to parse commits from
-    head: str
+    repo: Repository
+        The (remote) repo we want associate commits with
+    commit: git.Commit (GitPython)
         The commit SHA where we want to start from (usually tip of a branch)
 
     Returns
@@ -299,20 +229,10 @@ def make_commit(repo, c):
     )
 
 
-@click.command()
-@click.option('-h', '--host', default='localhost')
-@click.option('-p', '--port', default='8000')
-@click.option('-t', '--token', default='TOKEN')
-def main(host, port, token):
-    odb = connect(host, port, token)
-    service = LooperService(odb)
-    service.add_repo(
-        "test-looper", "https://github.com//aprioriinvestments/test-looper"
-    )
-    service.clone_repo("test-looper", "my-test-looper-clone")
-    service.scan_repo("my-test-looper-clone", branch="*")
-
-
-if __name__ == '__main__':
-    from object_database import connect
-    main()
+def _create_clone(conf: RepoConfig, clone_path):
+    if isinstance(conf, RepoConfig.Https):
+        GIT().clone(conf.url, clone_path, all_branches=True)
+    elif isinstance(conf, RepoConfig.Local):
+        GIT().clone(conf.path, clone_path, all_branches=True)
+    else:
+        raise NotImplementedError("Only public https cloning supported")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,9 @@
-import os
 import pytest
-import shutil
-
 from object_database.persistence import InMemoryPersistence
 from object_database.tcp_server import TcpServer, connect, DatabaseConnection
 from object_database.util import sslContextFromCertPathOrNone
 
 from test_looper import test_looper_schema
-
 # TODO read this from test configuration file
 from test_looper.service_schema import ArtifactStorageConfig, Config
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,5 +1,6 @@
 import json
 import os
+import pathlib
 
 import pytest
 
@@ -35,6 +36,13 @@ class TestGit:
     @pytest.mark.knownfailure
     def test_fail(self):
         assert 0 == 1
+
+    def test_clone_repo(self, tmp_path: pathlib.Path):
+        url = "https://github.com/aprioriinvestments/test-looper"
+        clone_path = tmp_path / 'test-looper'
+        GIT().clone(url, str(clone_path), all_branches=True)
+        assert clone_path.exists()
+        GitPythonRepo(clone_path)  # raises if it's not a git repository
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -24,7 +24,7 @@ def parser_service(odb_conn: DatabaseConnection,
                    template_repo: str,
                    tl_config: dict) -> ParserService:
     setup_repo(odb_conn, template_repo)
-    return ParserService(odb_conn)
+    return ParserService(odb_conn, tl_config["repo_url"])
 
 
 def setup_repo(odb_conn: DatabaseConnection, template_repo: str):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -12,13 +12,14 @@ from test_parser import parser_service, template_repo
 @pytest.fixture
 def dispatcher(odb_conn: DatabaseConnection,
                tl_config: dict) -> DispatchService:
-    return DispatchService(odb_conn)
+    return DispatchService(odb_conn, tl_config["repo_url"])
 
 
 @pytest.fixture
 def runner(odb_conn: DatabaseConnection,
            tl_config: dict) -> RunnerService:
-    return RunnerService(odb_conn, "tout seul")
+    return RunnerService(odb_conn, repo_url=tl_config["repo_url"],
+                         worker_id="tout seul")
 
 
 def test_assign_nodes(parser_service, dispatcher, runner):
@@ -57,7 +58,6 @@ def test_run_test(parser_service, dispatcher, runner):
     parser_service.parse_commits()
     with runner.db.transaction():
         node = TNode.lookupUnique()
-        name = node.name
         assert node.executionResultSummary is None
         node.isAssigned = True
         w = Worker.lookupOne(workerId=runner.worker_id)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -31,29 +31,30 @@ def test_add_repo(odb_conn: DatabaseConnection, tl_config: dict):
     }
     for name, url in repos.items():
         service.add_repo(name, url)
-    all_repos = service.get_all_repos()
-    for name, config in all_repos.items():
-        assert repos[name] == config.url
 
-    for name, url in repos.items():
-        config = service.get_repo_config(name)
-        assert isinstance(config, RepoConfig.Https)
-        assert config.url == url
+    with odb_conn.view():
+        for r in Repository.lookupAll():
+            assert repos[r.name] == r.config.url
+
+        for name, url in repos.items():
+            config = Repository.lookupOne(name=name).config
+            assert isinstance(config, RepoConfig.Https)
+            assert config.url == url
 
 
-def test_clone_repo(odb_conn: DatabaseConnection, tl_config: dict):
+def test_scan_repo(odb_conn: DatabaseConnection, tl_config: dict):
     service = LooperService.from_odb(odb_conn)
-    name = "test-looper"
-    config = service.add_repo(
-        name, "https://github.com/aprioriinvestments/test-looper"
+    service.add_repo(
+        "test-looper", "https://github.com/aprioriinvestments/test-looper"
     )
-    clone_name, clone_config = service.clone_repo(name, clone_name="clone")
-    assert clone_name == "clone"
-    assert isinstance(clone_config, RepoConfig.Local)
-    assert clone_config.path == f"{service.repo_url}/clone"
-    remote_name, remote_config = service.get_remote(clone_name)
-    assert remote_name == name
-    assert remote_config == config
+    service.scan_repo("test-looper", branch="*")
+    with odb_conn.view():
+        repo = Repository.lookupOne(name="test-looper")
+        is_found, clone_path = service.get_clone(repo)
+        assert is_found
+        for b in GIT().list_branches(clone_path):
+            odb_branch = Branch.lookupOne(repoAndName=(repo, b.name))
+            assert b.commit.hexsha == odb_branch.top_commit.sha
 
 
 def test_parse_repo():
@@ -87,22 +88,6 @@ def test_parse_branch(odb_conn: DatabaseConnection, tl_repo: Repo):
             _check_tree(
                 branch.commit, Commit.lookupOne(sha=branch.commit.hexsha)
             )
-
-
-def test_scan_repo(odb_conn: DatabaseConnection, tl_config: dict):
-    service = LooperService.from_odb(odb_conn)
-    service.add_repo(
-        "test-looper", "https://github.com/aprioriinvestments/test-looper"
-    )
-    (name, clone_conf) = service.clone_repo(
-        "test-looper", clone_name="test_scan_repo"
-    )
-    service.scan_repo("test_scan_repo", branch="*")
-    with service.db.view():
-        repo = Repository.lookupOne(name=name)
-        for b in GIT().list_branches(clone_conf.path):
-            odb_branch = Branch.lookupOne(repoAndName=(repo, b.name))
-            assert b.commit.hexsha == odb_branch.top_commit.sha
 
 
 def _check_tree(expected, odb_results):


### PR DESCRIPTION
Instead of creating explicit local clones, we want to make sure we're modeling the remote repo
so cloning should no longer be part of the TestLooper public API and is just managed as
implementation detail

closes #13 