### PR TITLE
Automatically run services in loops

### DIFF
--- a/scripts/start_services.py
+++ b/scripts/start_services.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import sys
+import tempfile
+import time
+
+from object_database.service_manager.ServiceManager import ServiceManager
+from object_database import connect, core_schema, service_schema
+from object_database.frontends.service_manager import startServiceManagerProcess
+
+from test_looper.parser import ParserService
+from test_looper.runner import RunnerService
+
+
+def main(service_classes, run_db=False):
+    odb_token = "TOKEN"
+    odb_host = "localhost"
+    odb_port = 8080
+    loglevel_name = "INFO"
+
+    with tempfile.TemporaryDirectory() as tmpDirName:
+        server = None
+        try:
+            server = startServiceManagerProcess(
+                tmpDirName, odb_port, odb_token, loglevelName=loglevel_name,
+                logDir=False, runDb=run_db
+            )
+
+            database = connect(odb_host, odb_port, odb_token, retry=True)
+            database.subscribeToSchema(core_schema, service_schema)
+
+            with database.transaction():
+                for s in service_classes:
+                    ServiceManager.createOrUpdateService(
+                        s, s.__name__, target_count=0
+                    )
+
+            for s in service_classes:
+                with database.transaction():
+                    ServiceManager.startService(s.__name__, 1)
+
+            while True:
+                time.sleep(0.1)
+        finally:
+            if server is not None:
+                server.terminate()
+                server.wait()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main([ParserService, RunnerService], run_db=True))

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+pytest -m "not knownfailure" --ignore=tests/_template_repo tests

--- a/test_looper/tl_git.py
+++ b/test_looper/tl_git.py
@@ -2,6 +2,7 @@
 # with GIT, github and related utilities
 
 import os
+import uuid
 import subprocess
 import sys
 import requests
@@ -48,12 +49,17 @@ class GIT:
         if not all_branches:
             return os.system(f"git clone {repo} {directory}")
         else:
+            # TODO clean this up and make thread-safe
+            tmp_dir = f"/tmp/{str(uuid.uuid4())}"
+            os.makedirs(tmp_dir, exist_ok=True)
             os.makedirs(directory, exist_ok=True)
             cmd = (
-                f"cd {directory} && "
+                f"cd {tmp_dir} && "
                 f"git clone --mirror {repo} .git && "
                 "git config --bool core.bare false && "
-                "git reset --hard"
+                "git reset --hard && "
+                f"rm -rf {directory} && "
+                f"mv {tmp_dir} {directory}"
             )
             return subprocess.check_output(cmd, shell=True)
 

--- a/test_looper/utils/services.py
+++ b/test_looper/utils/services.py
@@ -7,8 +7,6 @@ from object_database import connect
 
 from test_looper import test_looper_schema
 from test_looper.service import LooperService
-from test_looper.parser import ParserService
-from test_looper.runner import RunnerService, DispatchService
 from test_looper.tl_git import GIT
 
 
@@ -38,17 +36,9 @@ def run_tests(host, port, token, repo_url):
     # Register a repo and scan all branches for commits
     looper = LooperService(odb, repo_url=repo_url)
     looper.add_repo('template_repo', repo_url)
-    looper.scan_repo('template_repo', branch="*")
+    # looper.scan_repo('template_repo', branch="*")
 
-    # Parse commits and create test plan
-    parser = ParserService(odb, repo_url=repo_url)
-    parser.parse_commits()
-
-    # create a dispatcher to assign TestNodes
-    dispatch = DispatchService(odb, repo_url=repo_url)
     # register a worker
-    runner = RunnerService(odb, repo_url=repo_url, worker_id="tout seul")
-
-    dispatch.assign_nodes()  # this will assign it to the runner
-    runner.run_test()
+    #runner = RunnerService(odb, repo_url=repo_url, worker_id="tout seul")
+    #runner.run_test()
     return odb

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -5,6 +5,7 @@ from object_database.database_connection import DatabaseConnection
 import shutil
 
 from test_looper.parser import ParserService
+from test_looper.repo_schema import Repository
 from test_looper.service import LooperService
 from test_looper.test_schema import TestNode as TNode
 from test_looper.tl_git import GIT
@@ -24,7 +25,7 @@ def parser_service(odb_conn: DatabaseConnection,
                    template_repo: str,
                    tl_config: dict) -> ParserService:
     setup_repo(odb_conn, template_repo)
-    return ParserService(odb_conn, tl_config["repo_url"])
+    return ParserService(odb_conn, None, None, tl_config["repo_url"])
 
 
 def setup_repo(odb_conn: DatabaseConnection, template_repo: str):
@@ -32,7 +33,9 @@ def setup_repo(odb_conn: DatabaseConnection, template_repo: str):
     service.add_repo(
         "_template_repo", template_repo
     )
-    service.scan_repo("_template_repo", branch="*")
+    with odb_conn.transaction():
+        repo = Repository.lookupOne(name="_template_repo")
+        service.scan_repo(repo, branch="*")
 
 
 def test_parse_commits(parser_service: ParserService):

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -47,9 +47,9 @@ def test_scan_repo(odb_conn: DatabaseConnection, tl_config: dict):
     service.add_repo(
         "test-looper", "https://github.com/aprioriinvestments/test-looper"
     )
-    service.scan_repo("test-looper", branch="*")
-    with odb_conn.view():
+    with odb_conn.transaction():
         repo = Repository.lookupOne(name="test-looper")
+        service.scan_repo(repo, branch="*")
         is_found, clone_path = service.get_clone(repo)
         assert is_found
         for b in GIT().list_branches(clone_path):


### PR DESCRIPTION
Previously you had to manually execute all of the services to "step" through each iteration of scanning, parsing, testing.
This PR converts the test looper services into ODB ServiceBase's with Reactors.

## Parser service

    Every 10s, scan the repositories we know about for new commits.
    Separately, two reactors will be running:
    1. When new commits are added from the scan repo operation, parse
       the commits and add TestNodes
    2. If there are unexecuted TestNodes, assign them to free workers

## Runner service

    A RunnerService will run on a test-looper worker. It will look in odb for
    assigned TestNode's and execute the tests that are assigned to it. Once
    completed it will put TestResults back in ODB then go back to looking for
    assignments.

    Once every 10s, this runner should send a heartbeat (to ODB), so that bad
    workers can be killed by the overall system


For local convenience, added `test.sh` in the repo root so you don't need to explicitly pass in the markers to skip etc.





